### PR TITLE
Adds a skip flag to post

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,19 @@ The `name` values on your inputs will show up as labels in your notification, to
 
 Use the admin screen at `https://post.tableflip.io/routes` to configure a route for `https://butterfield-diet.com`, to tell it where to send the message, and where to redirect the user afterwards.
 
+## Skip the spam filter
+
+You can be in a situation where you just want to post to post and skip the Google's recaptcha. You can do this by adding a **"skip"** flag on your post's payload:
+
+```json
+  {
+    "name": "Bernard",
+    "email": "bernard@tableflip.io",
+    "open-source": "true",
+    "g-recaptcha-response": "skip"
+  }
+```
+
 ## Level DB
 
 See: http://dailyjs.com/2013/04/18/leveldb-and-node-1/

--- a/emails/spam.js
+++ b/emails/spam.js
@@ -7,7 +7,6 @@ function spamCheck (db, fetchRecaptchaResult, key, value) {
   // Check if it's our turn to run
   if (value && value.headers && value.headers.hasOwnProperty('X-Spam-Flag')) return
   if (!value.key || !value.body || !value.headers) return
-
   // Site hasn't provide a `g-recaptcha-response` so is misconfigured or is spam
   if (!value.body['g-recaptcha-response']) {
     console.log('Missing `g-recaptcha-response` param on post from ' + key)
@@ -28,6 +27,8 @@ function spamCheck (db, fetchRecaptchaResult, key, value) {
 
 // will call cb with (null, true) if value is from something more human than robot
 function fetchRecaptchaResult (value, cb) {
+  // if you know about post you can skip G recaptcha
+  if (value.body['g-recaptcha-response'] === 'skip') return cb(null, true)
   // ask G if it's spam.
   request({
     method: 'POST',
@@ -38,9 +39,9 @@ function fetchRecaptchaResult (value, cb) {
       remoteip: value.headers.remoteAddress
     }
   }, function (err, res, body) {
-      if (err) return cb(err)
-      const json = JSON.parse(body)
-      return cb(err, json.success)
+    if (err) return cb(err)
+    const json = JSON.parse(body)
+    return cb(err, json.success)
   })
 }
 
@@ -50,3 +51,4 @@ module.exports = function (db) {
 
 // for testing
 module.exports.spamCheck = spamCheck
+module.exports.fetchRecaptchaResult = fetchRecaptchaResult

--- a/pages/routes/server.js
+++ b/pages/routes/server.js
@@ -37,5 +37,3 @@ module.exports = function (app, db) {
     sendValues(db, makeKeys(), res)
   })
 }
-
-

--- a/test/emails/spam.test.js
+++ b/test/emails/spam.test.js
@@ -1,5 +1,6 @@
 const test = require('ava')
 const spamCheck = require('../../emails/spam').spamCheck
+const fetchRecaptchaResult = require('../../emails/spam').fetchRecaptchaResult
 
 test.cb('spam is deleted', t => {
   const message = {
@@ -72,4 +73,18 @@ test.cb('ham is preserved', t => {
     cb(null, true)
   }
   spamCheck(db, fetchRecaptchaResult, message.key, message)
+})
+
+test.cb('You can skip google recaptcha', t => {
+  const value = {
+    body: {
+      'g-recaptcha-response': 'skip'
+    }
+  }
+  const testCallback = (err, isHuman) => {
+    t.falsy(err, 'there is no error')
+    t.truthy(isHuman, 'you can skip validation')
+    t.end()
+  }
+  fetchRecaptchaResult(value, testCallback)
 })


### PR DESCRIPTION
We love `post`

But my robot was unable to send its payload through the service and I just wanted to skip the Google re-captcha step.

I figured on a simple flag that would skip the call to Google, and that's what is here in this PR. With this change, my bot can extract information and...

<img width="964" alt="screen shot 2017-10-11 at 12 22 01" src="https://user-images.githubusercontent.com/4499581/31437993-3409d59e-ae7f-11e7-8d34-ad60f78a4d6d.png">

... send an email to the team

<img width="932" alt="screen shot 2017-10-11 at 12 22 15" src="https://user-images.githubusercontent.com/4499581/31438043-61e76134-ae7f-11e7-99df-5a76609a717c.png">

**for discussion**

Is a simple "skip" value enough? `g-recaptcha` is protection from bots, for a bot to get around the re-captcha by knowing about our "skip" flag and manipulating the form fields to create a "g-recaptcha-response": "skip" then - fair play. Who wouldn't want to be getting emails from that kind of artificial intelligence?
