### PR TITLE
More helpful handling of redirects

### DIFF
--- a/pages/home/server.js
+++ b/pages/home/server.js
@@ -1,3 +1,4 @@
+var url = require('url')
 var crypto = require('crypto')
 var makeRouteKeys = require('../routes/keys')
 
@@ -39,9 +40,11 @@ module.exports = function (app, db) {
   }
 }
 
-// Return url if absolute. Append url to referer if not.
-function makeRedirect (url, referer) {
-  return url.indexOf('http') === 0 ? url : referer + url
+// Return url if absolute. Otherwise `resolve` the url aginst the referer.
+function makeRedirect (redirectUrl, referer) {
+  // We only support http(s) at the moment.
+  if (redirectUrl.indexOf('http') === 0) return redirectUrl
+  return url.resolve(referer, redirectUrl)
 }
 
 function makeValue (req, domain, path, route) {
@@ -64,3 +67,6 @@ function makeKey (value) {
   var key = ['msg', value.createdAt, hash].join('!')
   return key
 }
+
+// For testing
+module.exports.makeRedirect = makeRedirect

--- a/test/pages/home/server.test.js
+++ b/test/pages/home/server.test.js
@@ -15,6 +15,12 @@ test('Sensible redirects are chosen', t => {
   )
 
   t.is(
+    makeRedirect('sent-ok', 'https://tableflip.io/foo/contact-us/'),
+    'https://tableflip.io/foo/contact-us/sent-ok',
+    'and trailing slashes are a thing'
+  )
+
+  t.is(
     makeRedirect('../thanks', 'https://tableflip.io/foo/bar/contact-us'),
     'https://tableflip.io/foo/thanks',
     'traversals are traversed'

--- a/test/pages/home/server.test.js
+++ b/test/pages/home/server.test.js
@@ -1,0 +1,40 @@
+const test = require('ava')
+const makeRedirect = require('../../../pages/home/server').makeRedirect
+
+test('Sensible redirects are chosen', t => {
+  t.is(
+    makeRedirect('?sent=ok', 'https://tableflip.io'),
+    'https://tableflip.io/?sent=ok',
+    'Queries are appended'
+  )
+
+  t.is(
+    makeRedirect('sent-ok', 'https://tableflip.io/foo/contact-us'),
+    'https://tableflip.io/foo/sent-ok',
+    'path segments are resolved'
+  )
+
+  t.is(
+    makeRedirect('../thanks', 'https://tableflip.io/foo/bar/contact-us'),
+    'https://tableflip.io/foo/thanks',
+    'traversals are traversed'
+  )
+
+  t.is(
+    makeRedirect('./thanks', 'https://tableflip.io/foo/bar/contact-us'),
+    'https://tableflip.io/foo/bar/thanks',
+    'non traversals are non traversed'
+  )
+
+  t.is(
+    makeRedirect('/thankingz', 'https://tableflip.io/oh/me/oh/my/contact-us'),
+    'https://tableflip.io/thankingz',
+    'Domain relatives are resolved'
+  )
+
+  t.is(
+    makeRedirect('http://elsewhere.com', 'https://tableflip.io'),
+    'http://elsewhere.com',
+    'absolutes are returned absloutely'
+  )
+})


### PR DESCRIPTION
When a site posts to P O S T, we store the message and then redirect the user back to the site they came from. This PR improves the how we resolve where to redirect them to, so we can use the same config in testing as prod.

Relative urls are now supported. A success redirect config of`sent-ok` and a referer of `https://tableflip.io/foo` would be redirect to `https://tableflip.io/sent-ok`.

