### PR TITLE
Add support for mulitpart form posting.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -921,6 +921,21 @@
       "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=",
       "dev": true
     },
+    "basic-auth": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz",
+      "integrity": "sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+        }
+      }
+    },
     "basscss-align": {
       "version": "https://registry.npmjs.org/basscss-align/-/basscss-align-1.0.2.tgz",
       "integrity": "sha1-KUqmidb5nahuSvTFwokocIVcHDc=",
@@ -2657,6 +2672,14 @@
         }
       }
     },
+    "express-formidable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/express-formidable/-/express-formidable-1.0.0.tgz",
+      "integrity": "sha1-3JIvBFUTIyJFip7BowHYkbP/yo0=",
+      "requires": {
+        "formidable": "1.1.1"
+      }
+    },
     "extend": {
       "version": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
       "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ="
@@ -2835,7 +2858,8 @@
       }
     },
     "formidable": {
-      "version": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz",
       "integrity": "sha1-lriIb3w8NQi5Mta9cMTTqI818ak="
     },
     "forwarded": {
@@ -5610,6 +5634,38 @@
       "version": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
       "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
     },
+    "morgan": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.0.tgz",
+      "integrity": "sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=",
+      "requires": {
+        "basic-auth": "2.0.0",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+        "on-headers": "1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "depd": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+          "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "ms": {
       "version": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
       "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8=",
@@ -5955,6 +6011,11 @@
       "requires": {
         "ee-first": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
       }
+    },
+    "on-headers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
     },
     "once": {
       "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -8018,7 +8079,7 @@
         "debug": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
         "extend": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
         "form-data": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
-        "formidable": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz",
+        "formidable": "1.1.1",
         "methods": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
         "mime": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
         "qs": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -28,10 +28,12 @@
     "config": "^1.19.0",
     "corser": "^2.0.1",
     "express": "^4.13.4",
+    "express-formidable": "^1.0.0",
     "leveldown": "^1.4.4",
     "levelup": "^1.3.1",
     "mailgun-js": "^0.7.7",
-    "moment": "^2.12.0"
+    "moment": "^2.12.0",
+    "morgan": "^1.9.0"
   },
   "devDependencies": {
     "async": "^1.5.2",

--- a/pages/routes/server.js
+++ b/pages/routes/server.js
@@ -7,18 +7,19 @@ module.exports = function (app, db) {
 
   // Create route
   app.post('/routes', function (req, res) {
-    var referer = url.parse(req.body.referer, true, true)
+    console.log('ROUTE!', '/routes', req.url)
+    var referer = url.parse(req.fields.referer, true, true)
     var keys = makeKeys(referer.host, referer.path)
     var data = {
-      email: req.body.email,
-      referer: req.body.referer,
-      redirect: req.body.redirect,
-      redirectError: req.body.redirectError
+      email: req.fields.email,
+      referer: req.fields.referer,
+      redirect: req.fields.redirect,
+      redirectError: req.fields.redirectError
     }
     db.put(keys[0], data, function (err) {
       if (err) {
-        res.sendStatus(500)
-        console.error('Error routes', err.message)
+        console.log('Error routes', err.message)
+        return res.sendStatus(500)
       }
       res.redirect('back')
     })

--- a/server.js
+++ b/server.js
@@ -5,14 +5,17 @@ var spam = require('./emails/spam.js')(db)
 var config = require('config')
 var corser = require('corser')
 var express = require('express')
+var morgan = require('morgan')
 var bodyParser = require('body-parser')
+var formidable = require('express-formidable')
 
 var app = express()
 app.enable('trust proxy')
 app.disable('x-powered-by')
+app.use(morgan('short'))
 app.use(corser.create())
 app.use(express.static('dist'))
-app.use(bodyParser.urlencoded({ extended: false }))
+app.use(formidable())
 
 var routes = [
   require('./pages/routes/server.js'),


### PR DESCRIPTION
Switch to `express-formidable` middleware over `body-parser` so we can handle posts with multipart data.

The simplest way I've found to send a form from JS with graceful degradation to a regular post, without extra libs is:

```js
var form = document.querySelector('[data-id=email-form]')

fetch(form.action, {
        method: 'POST',
        mode: 'cors',
        body: new FormData(form)
      }).then(function(response) {
        if (response.ok) { /* hurray */ }
        else { throw }
     }).catch(/*handle errors */)
```

where `new FormData(form)` is the magic that takes a form and turns it into multipart form data that can be passed directly to fetch.

There is no option to change the encoding, so I've added smarts to POST to handle multipart forms.

`express-formidable`  uses the `req.fields` property rather than the `req.body` property, so there are some mechanical changes to switch code expecting a body prop.

I've added some logging, just out of interest. There is a bug where by posts to `/routes` also trigger the handler for `/:domain`, which due to a weird change in the shape of the not found error objects returned from level, was causing a crash whenever a route was updated. The fatal error is fixed, so the mulitple route handlers running is now harmless. A proper fix for that would probably require moving the `/:domain` route under it's own path like `/handle/:domain`, which'd require us to go tweak all existing sites. so I'm not gonna do that.